### PR TITLE
Improve likelihood of not staying at 0 or maximum

### DIFF
--- a/rng/random_generator.go
+++ b/rng/random_generator.go
@@ -43,9 +43,22 @@ func (rng *RandomDemand) GetDemand(taskType string) (int, error) {
 	case "priority1": // TODO! Priority name shouldn't be hard-coded like this
 		// Random value between +/- delta is the same as
 		// (random value between 0 and 2*delta) - delta
+		// Using l_delta and r_delta means we don't have a 50% chance of staying the same value if we're
+		// at one extreme or another of the allowed range
+
+		l_delta := rng.delta
+		if rng.currentP1Demand < rng.delta {
+			l_delta = rng.currentP1Demand
+		}
+
+		r_delta := rng.delta
+		if rng.currentP1Demand > (rng.maximum - rng.delta) {
+			r_delta = rng.maximum - rng.currentP1Demand
+		}
+
 		// noting that if r = rand.Intn(n) then 0 <= r < n
-		r := rand.Intn((2 * rng.delta) + 1)
-		newDemand = rng.currentP1Demand + r - rng.delta
+		r := rand.Intn((l_delta + r_delta) + 1)
+		newDemand = rng.currentP1Demand + r - l_delta
 		if newDemand > rng.maximum {
 			newDemand = rng.maximum
 		}

--- a/rng/random_generator_test.go
+++ b/rng/random_generator_test.go
@@ -16,6 +16,7 @@ func TestRandomDemand(t *testing.T) {
 		old_demand := rng.currentP1Demand
 		demand1, _ := rng.GetDemand("priority1")
 		demand2, _ := rng.GetDemand("priority2")
+		log.Printf("Demand changed from %d to %d", old_demand, demand1)
 
 		if demand1 > maximum || demand2 > maximum {
 			t.Fatalf("Random value exceeds maximum")
@@ -28,7 +29,6 @@ func TestRandomDemand(t *testing.T) {
 		if math.Abs(float64(demand1)-float64(old_demand)) > float64(delta) {
 			t.Fatalf("Random value varied more than the delta")
 		}
-		log.Printf("Demand changed from %d to %d", old_demand, demand1)
 	}
 
 	// Right now you should only pass in priority1 or priority2


### PR DESCRIPTION
RNG was generating the random value centered around the current value, and then cutting it off if < 0 or > maximum, which meant that at either extreme you had a 50% likelihood of staying put rather than varying demand.  